### PR TITLE
add first metrics in blocks & return them in response

### DIFF
--- a/src/controllers/blocks/BlocksController.ts
+++ b/src/controllers/blocks/BlocksController.ts
@@ -251,6 +251,7 @@ export default class BlocksController extends AbstractController<BlocksService> 
 		},
 		res,
 	): Promise<void> => {
+		let start = performance.now();
 		const checkFinalized = isHex(number);
 		const hash = await this.getHashForBlock(number);
 
@@ -309,6 +310,8 @@ export default class BlocksController extends AbstractController<BlocksService> 
 		if (res.locals.metrics) {
 			this.emitExtrinsicMetrics(block.extrinsics.length, 1, method, path, res);
 		}
+		const end = performance.now();
+		console.log(`Execution time in Controller - getBlockById: ${end - start} ms`);
 	};
 
 	/**

--- a/src/types/responses/Block.ts
+++ b/src/types/responses/Block.ts
@@ -35,6 +35,7 @@ export interface IBlock {
 	onFinalize: IOnInitializeOrFinalize;
 	finalized: boolean | undefined;
 	decodedXcmMsgs?: IMessages | undefined;
+	performanceMetrics?: { [id: string]: number } | undefined;
 }
 
 interface IOnInitializeOrFinalize {


### PR DESCRIPTION
Adding metrics in `blocks` endpoint to test and measure Sidecar's performance.